### PR TITLE
Fix meal planner persistence path to be rooted at server directory

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,7 +16,7 @@ app.use("/uploads", express.static(UPLOADS_DIR));
 
 console.log("Serving uploads from:", UPLOADS_DIR);
 
-const DATA_PATH = path.resolve("data/meal-planner.json");
+const DATA_PATH = path.join(SERVER_ROOT, "data", "meal-planner.json");
 
 export type WeekPlan = {
     saturday: string | null;


### PR DESCRIPTION
### Motivation
- The planner persistence path used `path.resolve("data/meal-planner.json")`, which resolves relative to the process CWD and can point to the wrong location when the server is started outside the `server/` folder (e.g. monorepos, PM2, systemd), so it should be rooted at `SERVER_ROOT` for deterministic behavior.

### Description
- Replace `const DATA_PATH = path.resolve("data/meal-planner.json");` with `const DATA_PATH = path.join(SERVER_ROOT, "data", "meal-planner.json");` in `server/src/server.ts` so reads/writes target the server's data directory.

### Testing
- Ran `npm run build` which failed in this environment with `vite: not found`, and an attempted `npm install --include=dev` did not complete successfully, so the build could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b67ed96c832f83e863878b16e8ad)