### PR TITLE
Make frontend API base URL deployment-safe

### DIFF
--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import { Recipe } from "../types/recipe";
-
-const API_BASE_URL = "http://localhost:4000";
+import { toApiUrl } from "../utils/api";
 
 
 type Props = {
@@ -22,7 +21,7 @@ export default function RecipeCard({ recipe }: Props) {
     >
       {recipe.image ? (
               <img
-                  src={`${API_BASE_URL}${recipe.image.replace(/^\.\//, "/")}`}
+                  src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
                   alt={recipe.title}
                   className="rounded-xl mb-3 h-40 w-full object-cover"
                   loading="lazy"

--- a/src/hooks/useMealPlanner.ts
+++ b/src/hooks/useMealPlanner.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toApiUrl } from "../utils/api";
 
 export type WeekPlan = {
     saturday: string | null;
@@ -20,9 +21,6 @@ const EMPTY_WEEK: WeekPlan = {
     friday: null
 };
 
-
-const API_BASE_URL = "http://localhost:4000";
-
 export function useMealPlanner(weekKey: string, isEditable: boolean) {
     const [plan, setPlan] = useState<WeekPlan>(EMPTY_WEEK);
 
@@ -30,7 +28,7 @@ export function useMealPlanner(weekKey: string, isEditable: boolean) {
         let cancelled = false;
 
         async function load() {
-            const res = await fetch(`${API_BASE_URL}/planner/${weekKey}`);
+            const res = await fetch(toApiUrl(`/planner/${weekKey}`));
             const data = await res.json();
             if (!cancelled) setPlan(data ?? EMPTY_WEEK);
         }
@@ -50,7 +48,7 @@ export function useMealPlanner(weekKey: string, isEditable: boolean) {
         const updated = { ...plan, [day]: recipeId };
         setPlan(updated);
 
-        await fetch(`${API_BASE_URL}/planner/${weekKey}`, {
+        await fetch(toApiUrl(`/planner/${weekKey}`), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(updated)

--- a/src/pages/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail.tsx
@@ -1,6 +1,7 @@
 ﻿import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useRecipes } from "../hooks/useRecipes";
+import { toApiUrl } from "../utils/api";
 
 function getDomain(url: string): string {
   try {
@@ -14,7 +15,6 @@ export default function RecipeDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const recipes = useRecipes();
-  const API_BASE_URL = "http://localhost:4000";
 
   const recipe = useMemo(() => recipes.find((r) => r.id === id), [recipes, id]);
 
@@ -33,7 +33,7 @@ export default function RecipeDetail() {
 
           {recipe.image && (
               <img
-                  src={`${API_BASE_URL}${recipe.image.replace(/^\.\//, "/")}`}
+                  src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
                   alt={recipe.title}
                   className="rounded-2xl mb-6 w-full object-cover"
                   loading="lazy"

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,8 @@
+const rawApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() ?? "";
+
+const normalizedApiBaseUrl = rawApiBaseUrl.replace(/\/$/, "");
+
+export function toApiUrl(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedApiBaseUrl}${normalizedPath}`;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### Motivation
- The frontend used a hardcoded `http://localhost:4000` which breaks deployments behind proxies or on different hosts/HTTPS.
- The change makes API requests and image URLs configurable so the app can run behind reverse proxies or with a different backend host.
- Skills used: none — this is a straightforward localized refactor of frontend URL handling.

### Description
- Added `src/utils/api.ts` implementing `toApiUrl(path: string)` which reads `import.meta.env.VITE_API_BASE_URL`, trims it, removes a trailing slash, and builds normalized URLs.
- Added `src/vite-env.d.ts` to type `VITE_API_BASE_URL` for TypeScript awareness.
- Replaced hardcoded `http://localhost:4000` usage with `toApiUrl(...)` in `src/hooks/useMealPlanner.ts`, `src/components/RecipeCard.tsx`, and `src/pages/RecipeDetail.tsx` so both planner requests and recipe image URLs are environment-aware.

### Testing
- Ran `npm run build` (Vite production build) and it completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b89ad458832f83e3cdadba87de97)