### PR TITLE
Handle planner API failures and rollback optimistic updates in useMealPlanner

### DIFF
--- a/src/hooks/useMealPlanner.ts
+++ b/src/hooks/useMealPlanner.ts
@@ -29,6 +29,10 @@ export function useMealPlanner(weekKey: string, isEditable: boolean) {
 
         async function load() {
             const res = await fetch(toApiUrl(`/planner/${weekKey}`));
+            if (!res.ok) {
+                throw new Error(`Unable to load planner for week: ${weekKey}`);
+            }
+
             const data = await res.json();
             if (!cancelled) setPlan(data ?? EMPTY_WEEK);
         }
@@ -45,14 +49,24 @@ export function useMealPlanner(weekKey: string, isEditable: boolean) {
     async function updateDay(day: keyof WeekPlan, recipeId: string) {
         if (!isEditable) return;
 
+        const previous = plan;
         const updated = { ...plan, [day]: recipeId };
         setPlan(updated);
 
-        await fetch(toApiUrl(`/planner/${weekKey}`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(updated)
-        });
+        try {
+            const res = await fetch(toApiUrl(`/planner/${weekKey}`), {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(updated)
+            });
+
+            if (!res.ok) {
+                throw new Error(`Unable to save planner for week: ${weekKey}`);
+            }
+        } catch (error) {
+            console.error(error);
+            setPlan(previous);
+        }
     }
 
     return { plan, updateDay };


### PR DESCRIPTION
### Motivation
- The meal planner hook previously attempted to parse planner responses as JSON even for non-2xx responses, which could mask server errors and produce invalid state. 
- Optimistic UI updates for drag/drop assignments could leave unsaved state visible if the POST request failed. 
- Add explicit error handling and rollback to keep the UI consistent and make failures easier to diagnose.

### Description
- Added an HTTP status check when loading planner data so non-OK responses throw an error instead of being parsed as JSON (`useMealPlanner` load path). 
- Preserve the previous `plan` value and continue using optimistic updates for the UI, then attempt to persist changes with a `POST` request. 
- Wrap the save request in a `try/catch`, log failures to the console, and rollback to the preserved `previous` plan on error. 
- No public API changes; the hook still returns `{ plan, updateDay }` and keeps the same parameters.

### Testing
- Ran the production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b9b946d0832f838fd054ec8e46e6)