### PR TITLE
Fix recipe image rendering and API URL resolution

### DIFF
--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router-dom";
 import { Recipe } from "../types/recipe";
 import { toApiUrl } from "../utils/api";
 
-
 type Props = {
   recipe: Recipe;
 };
@@ -20,17 +19,13 @@ export default function RecipeCard({ recipe }: Props) {
       title="Drag to planner"
     >
       {recipe.image ? (
-              <img
-                  src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
-                  alt={recipe.title}
-                  className="rounded-xl mb-3 h-40 w-full object-cover"
-                  loading="lazy"
-              />
-      ) : (
-        <div className="rounded-xl mb-3 h-40 w-full bg-neutral-100 flex items-center justify-center text-neutral-500 text-sm">
-          No image
-        </div>
-      )}
+        <img
+          src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
+          alt={recipe.title}
+          className="rounded-xl mb-3 h-40 w-full object-cover"
+          loading="lazy"
+        />
+      ) : null}
 
       <h2 className="text-xl font-semibold leading-snug">{recipe.title}</h2>
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,8 +1,28 @@
 const rawApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() ?? "";
-
 const normalizedApiBaseUrl = rawApiBaseUrl.replace(/\/$/, "");
 
+const DEFAULT_API_ORIGIN = "http://localhost:4000";
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function shouldUseApiOrigin(path: string): boolean {
+  return path.startsWith("/planner/") || path.startsWith("/uploads/");
+}
+
 export function toApiUrl(path: string): string {
+  if (isAbsoluteUrl(path)) return path;
+
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  return `${normalizedApiBaseUrl}${normalizedPath}`;
+
+  if (normalizedApiBaseUrl) {
+    return `${normalizedApiBaseUrl}${normalizedPath}`;
+  }
+
+  if (shouldUseApiOrigin(normalizedPath)) {
+    return `${DEFAULT_API_ORIGIN}${normalizedPath}`;
+  }
+
+  return normalizedPath;
 }


### PR DESCRIPTION
### Motivation
- Recipe cards showed a placeholder block when no image was present and uploaded images under `/uploads` were not loading in the default local setup. 
- The app needs to correctly resolve image and planner URLs when `VITE_API_BASE_URL` is not set so local server-hosted uploads and planner routes load from the API origin. 
- Preserve support for absolute URLs and same-origin paths while ensuring `/uploads/*` and `/planner/*` are routed to the running server.

### Description
- Removed the card fallback placeholder in `src/components/RecipeCard.tsx` so cards with no `image` now render without a placeholder block and images continue to render when present. 
- Reworked `src/utils/api.ts` to add `DEFAULT_API_ORIGIN`, `isAbsoluteUrl`, and `shouldUseApiOrigin`, and updated `toApiUrl` to: return absolute URLs unchanged, use `VITE_API_BASE_URL` when set, route `/uploads/*` and `/planner/*` to `http://localhost:4000` when `VITE_API_BASE_URL` is empty, and otherwise return normalized same-origin paths. 
- Kept existing behavior for normal same-origin paths and absolute URLs.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Executed an automated Playwright script which loaded the app, searched for `koshari`, and produced a screenshot confirming the uploaded image renders in the recipe card (script completed successfully). 
- Started the frontend and server during verification and confirmed the API served uploads at `/uploads` while the app resolved the image URL correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c2d864ec832fbd3c243f4e8cdc2a)