### PR TITLE
Add image fallback component and local uploads guidance

### DIFF
--- a/public/uploads/README.md
+++ b/public/uploads/README.md
@@ -1,0 +1,5 @@
+# Local upload assets
+
+This folder is intentionally kept text-only in git.
+
+To use recipe images locally, add your image files here (for example `koshari.jpeg`) so paths like `/uploads/koshari.jpeg` resolve from the frontend static server.

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Recipe } from "../types/recipe";
 import { toApiUrl } from "../utils/api";
+import RecipeImage from "./RecipeImage";
 
 type Props = {
   recipe: Recipe;
@@ -19,11 +20,11 @@ export default function RecipeCard({ recipe }: Props) {
       title="Drag to planner"
     >
       {recipe.image ? (
-        <img
+        <RecipeImage
           src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
           alt={recipe.title}
           className="rounded-xl mb-3 h-40 w-full object-cover"
-          loading="lazy"
+          placeholderClassName="rounded-xl mb-3 h-40 w-full bg-neutral-100"
         />
       ) : null}
 

--- a/src/components/RecipeImage.tsx
+++ b/src/components/RecipeImage.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+type Props = {
+  src: string;
+  alt: string;
+  className?: string;
+  placeholderClassName?: string;
+};
+
+export default function RecipeImage({
+  src,
+  alt,
+  className,
+  placeholderClassName,
+}: Props) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div
+        aria-label={`Image unavailable for ${alt}`}
+        className={placeholderClassName}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/pages/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail.tsx
@@ -1,5 +1,6 @@
-﻿import { useMemo } from "react";
+import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import RecipeImage from "../components/RecipeImage";
 import { useRecipes } from "../hooks/useRecipes";
 import { toApiUrl } from "../utils/api";
 
@@ -27,18 +28,16 @@ export default function RecipeDetail() {
         className="mb-4 text-blue-600 hover:underline"
       >
         ← Back
-          </button>
+      </button>
 
-          
-
-          {recipe.image && (
-              <img
-                  src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
-                  alt={recipe.title}
-                  className="rounded-2xl mb-6 w-full object-cover"
-                  loading="lazy"
-              />
-          )}
+      {recipe.image && (
+        <RecipeImage
+          src={toApiUrl(recipe.image.replace(/^\.\//, "/"))}
+          alt={recipe.title}
+          className="rounded-2xl mb-6 w-full object-cover"
+          placeholderClassName="rounded-2xl mb-6 h-64 w-full bg-neutral-100"
+        />
+      )}
 
       <h1 className="text-4xl font-bold mb-2">{recipe.title}</h1>
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,14 +1,22 @@
 const rawApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim() ?? "";
 const normalizedApiBaseUrl = rawApiBaseUrl.replace(/\/$/, "");
 
-const DEFAULT_API_ORIGIN = "http://localhost:4000";
+function getDefaultApiOrigin(): string {
+  if (typeof window === "undefined") {
+    return "http://localhost:4000";
+  }
+
+  const hostname = window.location.hostname || "localhost";
+
+  return `http://${hostname}:4000`;
+}
 
 function isAbsoluteUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
 function shouldUseApiOrigin(path: string): boolean {
-  return path.startsWith("/planner/") || path.startsWith("/uploads/");
+  return path.startsWith("/planner/");
 }
 
 export function toApiUrl(path: string): string {
@@ -21,7 +29,7 @@ export function toApiUrl(path: string): string {
   }
 
   if (shouldUseApiOrigin(normalizedPath)) {
-    return `${DEFAULT_API_ORIGIN}${normalizedPath}`;
+    return `${getDefaultApiOrigin()}${normalizedPath}`;
   }
 
   return normalizedPath;


### PR DESCRIPTION
### Motivation
- Provide resilient image rendering so broken or missing recipe images show a styled placeholder instead of a broken image UI.
- Allow developers to add local recipe image assets in a git-friendly way under `public/uploads` while keeping them served as frontend static files.
- Make API URL construction robust in different environments by deriving the default API origin from the current browser hostname.

### Description
- Add `src/components/RecipeImage.tsx`, a small component that renders an `<img>` with `loading="lazy"` and falls back to a placeholder `div` when the image `onError` fires.
- Replace raw `<img>` usage with `RecipeImage` in `src/components/RecipeCard.tsx` and `src/pages/RecipeDetail.tsx`, adding `placeholderClassName` for consistent sizing and styling.
- Update `src/utils/api.ts` to compute the default API origin via `getDefaultApiOrigin()` and stop routing `/uploads/*` through the API origin so frontend static uploads resolve directly.
- Add `public/uploads/README.md` documenting how to place local upload assets in a text-only folder tracked by git.

### Testing
- Ran `npm run build` successfully with `vite` producing production assets.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured an automated Playwright screenshot of the updated UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6cf26cd54832fa8cd777e1d9b0f23)