### PR TITLE
Constrain weekly planner panel to viewport height

### DIFF
--- a/src/components/WeeklyPlanner.tsx
+++ b/src/components/WeeklyPlanner.tsx
@@ -86,7 +86,7 @@ export default function WeeklyPlanner({ recipes }: Props) {
 
 
     return (
-        <div className="bg-white rounded-2xl shadow-md p-4 sticky top-4">
+        <div className="bg-white rounded-2xl shadow-md p-4 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
             <div className="flex items-center justify-between mb-3">
                 <button
                     onClick={() => setSelectedWeekKey(shiftWeekKey(selectedWeekKey, -1))}


### PR DESCRIPTION
### Motivation
- Prevent the right-side weekly planner panel from exceeding the viewport height so the sticky panel no longer causes awkward page-level scrolling and manual adjustment.

### Description
- Limit the planner container height and enable internal scrolling by adding Tailwind classes `max-h-[calc(100vh-2rem)]` and `overflow-y-auto` to the wrapper in `src/components/WeeklyPlanner.tsx` while preserving the existing `sticky top-4` behavior.

### Testing
- Ran `npm run build` which completed successfully, and started the dev server and captured a Playwright screenshot of the updated UI to validate the layout change (screenshot capture succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f1441c3c832fb6eb5a26ef066a05)